### PR TITLE
Add junk autoremove control

### DIFF
--- a/src/clidef.rs
+++ b/src/clidef.rs
@@ -54,8 +54,10 @@ pub fn cli(version: &'static str) -> Command {
             Arg::new("autodeps")
                 .short('a')
                 .long("autodeps")
-                .action(clap::ArgAction::SetTrue)
-                .help(format!("Include graph of package dependencies\n{}", "NOTE: This can increase the size, but might not always be useful".yellow()))
+                .default_value("none")
+                .value_name("mode")
+                .value_parser(["free", "clean", "none"])
+                .help(format!("Auto-add package dependencies.\n{}", " NOTE: This can increase the size, but might not always be useful\n".yellow()))
         )
         .arg(
             Arg::new("root")

--- a/src/clidef.rs
+++ b/src/clidef.rs
@@ -56,7 +56,7 @@ pub fn cli(version: &'static str) -> Command {
                 .long("autodeps")
                 .default_value("none")
                 .value_name("mode")
-                .value_parser(["free", "clean", "none"])
+                .value_parser(["free", "clean", "tight", "none"])
                 .help(format!("Auto-add package dependencies.\n{}", " NOTE: This can increase the size, but might not always be useful\n".yellow()))
         )
         .arg(

--- a/src/filters/resources.rs
+++ b/src/filters/resources.rs
@@ -88,11 +88,16 @@ impl ResourcesDataFilter {
 
 impl DataFilter for ResourcesDataFilter {
     fn filter(&self, data: &mut HashSet<PathBuf>) {
+        if self.autodeps == Autodeps::Clean || self.autodeps == Autodeps::Tight {
+            log::info!("Automatically removing potential junk resources");
+        }
+
         let mut out: Vec<PathBuf> = Vec::default();
         for p in &self.data {
             if self.filter_archives(p)
                 || self.filter_images(p)
-                || (self.autodeps == Autodeps::Clean && ResourcesDataFilter::is_potential_junk(p.to_str().unwrap()))
+                || ((self.autodeps == Autodeps::Clean || self.autodeps == Autodeps::Tight)
+                    && ResourcesDataFilter::is_potential_junk(p.file_name().unwrap().to_str().unwrap()))
             {
                 continue;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn main() -> Result<(), std::io::Error> {
     if let Err(err) = procdata::TintProcessor::new(rpth)
         .set_profile(get_profile(cli, &params))
         .set_dry_run(params.get_flag("dry-run"))
-        .set_autodeps(params.get_flag("autodeps"))
+        .set_autodeps(params.get_one::<String>("autodeps").unwrap().to_string())
         .start()
     {
         log::error!("{}", err);

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -15,11 +15,12 @@ use std::{
 };
 
 /// Autodependency mode
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Autodeps {
     Undef,
     Free,
     Clean,
+    Tight,
 }
 /// Main processing of profiles or other data
 #[derive(Clone)]
@@ -52,6 +53,7 @@ impl TintProcessor {
         match ad.as_str() {
             "free" => self.autodeps = Autodeps::Free,
             "clean" => self.autodeps = Autodeps::Clean,
+            "tight" => self.autodeps = Autodeps::Tight,
             _ => self.autodeps = Autodeps::Undef,
         }
 

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -14,18 +14,25 @@ use std::{
     path::{Path, PathBuf},
 };
 
+/// Autodependency mode
+#[derive(Clone, Copy, PartialEq)]
+pub enum Autodeps {
+    Undef,
+    Free,
+    Clean,
+}
 /// Main processing of profiles or other data
 #[derive(Clone)]
 pub struct TintProcessor {
     profile: Profile,
     root: PathBuf,
     dry_run: bool,
-    autodeps: bool,
+    autodeps: Autodeps,
 }
 
 impl TintProcessor {
     pub fn new(root: PathBuf) -> Self {
-        TintProcessor { profile: Profile::default(), root, dry_run: true, autodeps: false }
+        TintProcessor { profile: Profile::default(), root, dry_run: true, autodeps: Autodeps::Free }
     }
 
     /// Set configuration from a profile
@@ -41,8 +48,13 @@ impl TintProcessor {
     }
 
     /// Set flag for automatic dependency tracing
-    pub fn set_autodeps(&mut self, ad: bool) -> &mut Self {
-        self.autodeps = ad;
+    pub fn set_autodeps(&mut self, ad: String) -> &mut Self {
+        match ad.as_str() {
+            "free" => self.autodeps = Autodeps::Free,
+            "clean" => self.autodeps = Autodeps::Clean,
+            _ => self.autodeps = Autodeps::Undef,
+        }
+
         self
     }
 
@@ -160,7 +172,7 @@ impl TintProcessor {
         // and then let TextDataFilter removes what still should be removed.
         // The idea is to keep parts only relevant to the runtime.
         log::debug!("Filtering packages");
-        let pscan = DebPackageScanner::new(false); // XXX: Maybe --autodeps=LEVEL to optionally include these too?
+        let pscan = DebPackageScanner::new(Autodeps::Undef);
         for p in self.profile.get_packages() {
             log::debug!("Getting content of package \"{}\"", p);
             paths.extend(pscan.get_package_contents(p.to_string())?);
@@ -186,7 +198,8 @@ impl TintProcessor {
 
         // Remove resources
         log::debug!("Filtering resources");
-        ResourcesDataFilter::new(paths.clone().into_iter().collect::<Vec<PathBuf>>(), self.profile.to_owned()).filter(&mut paths);
+        ResourcesDataFilter::new(paths.clone().into_iter().collect::<Vec<PathBuf>>(), self.profile.to_owned(), self.autodeps)
+            .filter(&mut paths);
 
         // Scan rootfs
         log::debug!("Scanning existing rootfs");

--- a/src/scanner/debpkg.rs
+++ b/src/scanner/debpkg.rs
@@ -1,7 +1,10 @@
-use crate::scanner::{
-    general::{Scanner, ScannerCommons},
-    tracedeb,
-    traceitf::PkgDepTrace,
+use crate::{
+    procdata::Autodeps,
+    scanner::{
+        general::{Scanner, ScannerCommons},
+        tracedeb,
+        traceitf::PkgDepTrace,
+    },
 };
 use colored::Colorize;
 use std::{
@@ -13,12 +16,12 @@ use std::{
 /// a target belongs to.
 pub struct DebPackageScanner {
     commons: ScannerCommons,
-    autodeps: bool,
+    autodeps: Autodeps,
 }
 
 impl DebPackageScanner {
     /// Constructor
-    pub fn new(autodeps: bool) -> Self {
+    pub fn new(autodeps: Autodeps) -> Self {
         DebPackageScanner { commons: ScannerCommons::new(), autodeps }
     }
 
@@ -106,7 +109,7 @@ impl Scanner for DebPackageScanner {
                 }
             }
 
-            if self.autodeps {
+            if self.autodeps != Autodeps::Undef {
                 // Trace dependencies graph for the package
                 for p in tracedeb::DebPackageTrace::new().trace(pkgname.to_owned()) {
                     log::info!("Keeping dependency package: {}", p.bright_yellow());

--- a/src/scanner/debpkg.rs
+++ b/src/scanner/debpkg.rs
@@ -109,7 +109,7 @@ impl Scanner for DebPackageScanner {
                 }
             }
 
-            if self.autodeps != Autodeps::Undef {
+            if self.autodeps == Autodeps::Clean || self.autodeps == Autodeps::Free {
                 // Trace dependencies graph for the package
                 for p in tracedeb::DebPackageTrace::new().trace(pkgname.to_owned()) {
                     log::info!("Keeping dependency package: {}", p.bright_yellow());


### PR DESCRIPTION
This allows to control junkfiles autoremoval:

    --autodeps <mode>

There are has four (three, really) modes:
- free
  Leave junkfiles, only show them at dry-run
- clean
  Remove junkfiles
- tight
  Remove junkfiles, but do not auto-resolve extra packages

Kind of complex combination, might be reworked in a future...