### PR TITLE
Add dropped packages option

### DIFF
--- a/doc/profiles.md
+++ b/doc/profiles.md
@@ -43,6 +43,10 @@ config:
         # Matches empty directories or directories with emnpty subdirectories
         - dir
 
+        # Replase all the above
+        - all
+
+
     # Specific paths that were not automatically detected
     # as not needed. Unix glob is used to be more specific, if needed.
     prune:

--- a/doc/profiles.md
+++ b/doc/profiles.md
@@ -14,8 +14,13 @@ targets:
 
 # List of preserved packages.
 packages:
-    - bash
-    - apt
+    # "Plus" or just a package name
+    # will retain it
+    - +bash
+    - +apt
+
+    # "Minus" explicitly says remove the package
+    - -blah
 
 # Profile config
 config:

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -31,6 +31,7 @@ pub struct Profile {
     f_expl_keep: Vec<PathBuf>,
 
     packages: Vec<String>,
+    dropped_packages: Vec<String>,
     targets: Vec<String>,
 }
 
@@ -48,6 +49,7 @@ impl Profile {
             f_img: true,
             f_arc: true,
             packages: vec![],
+            dropped_packages: vec![],
             targets: vec![],
             f_expl_prune: vec![],
             f_expl_keep: vec![],
@@ -111,7 +113,20 @@ impl Profile {
         self.targets.extend(p.targets);
 
         if let Some(pkgs) = p.packages {
-            self.packages.extend(pkgs);
+            for p in &pkgs {
+                let mut p = p.replace(' ', "");
+                if let Some(p) = p.strip_prefix('-') {
+                    log::debug!("Dropping contents from package \"{}\"", p);
+                    self.dropped_packages.push(p.to_string());
+                    continue;
+                }
+
+                if let Some(s) = p.strip_prefix('+') {
+                    p = s.to_string();
+                }
+
+                self.packages.push(p);
+            }
         }
 
         Ok(())
@@ -249,5 +264,10 @@ impl Profile {
     /// Get packages
     pub fn get_packages(&self) -> &Vec<String> {
         &self.packages
+    }
+
+    /// Get dropped packages
+    pub fn get_dropped_packages(&self) -> &Vec<String> {
+        &self.dropped_packages
     }
 }

--- a/src/scanner/binlib.rs
+++ b/src/scanner/binlib.rs
@@ -41,4 +41,9 @@ impl Scanner for ElfScanner {
         log::debug!("Scanning for dependencies in {}", pth.to_str().unwrap());
         self.get_dynlibs(pth.to_str().unwrap().to_string()).iter().map(PathBuf::from).collect::<Vec<PathBuf>>()
     }
+
+    /// Bogus trait implementation, does nothing in this case
+    fn exclude(&mut self, _: Vec<String>) -> &mut Self {
+        self
+    }
 }

--- a/src/scanner/general.rs
+++ b/src/scanner/general.rs
@@ -1,7 +1,11 @@
 use std::{fs, io::Error, path::PathBuf, process::Command};
 
 pub(crate) trait Scanner {
+    /// Scan path
     fn scan(&mut self, pth: PathBuf) -> Vec<PathBuf>;
+
+    /// Add packages to be excluded from the scan
+    fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self;
 }
 
 pub struct ScannerCommons {

--- a/src/scanner/tracedeb.rs
+++ b/src/scanner/tracedeb.rs
@@ -3,11 +3,12 @@ use std::{collections::HashSet, process::Command};
 
 pub struct DebPackageTrace {
     data: HashSet<String>,
+    exclude: HashSet<String>,
 }
 
 impl DebPackageTrace {
     pub fn new() -> Self {
-        DebPackageTrace { data: HashSet::default() }
+        DebPackageTrace { data: HashSet::default(), exclude: HashSet::default() }
     }
 
     /// Get list of package dependencies for the first nearby level
@@ -57,6 +58,14 @@ impl PkgDepTrace for DebPackageTrace {
     fn trace(&mut self, pkgname: String) -> Vec<String> {
         log::info!("Getting dependencies for a package {}", pkgname);
 
-        self.get_dependencies(pkgname, true)
+        let mut d = self.get_dependencies(pkgname, true);
+        d.retain(|p| !self.exclude.contains(p));
+
+        d
+    }
+
+    fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self {
+        self.exclude.extend(pkgs);
+        self
     }
 }

--- a/src/scanner/traceitf.rs
+++ b/src/scanner/traceitf.rs
@@ -1,4 +1,5 @@
 /// Package dependency trace
 pub trait PkgDepTrace {
     fn trace(&mut self, pkgname: String) -> Vec<String>;
+    fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self;
 }


### PR DESCRIPTION
Profile can now explicitly drop dangling packages with prefixing `-` (minus):
```yaml
packages:
  - -bash
```