### PR TITLE
Add packagelist for the dry-run

### DIFF
--- a/src/scanner/debftrace.rs
+++ b/src/scanner/debftrace.rs
@@ -1,0 +1,64 @@
+use crate::rootfs::RootFS;
+
+use super::traceitf::PkgFileTrace;
+use std::{
+    collections::HashMap,
+    fs::{self, DirEntry},
+    path::PathBuf,
+};
+
+pub struct DebPkgFileTrace {
+    file_to_pkg: HashMap<PathBuf, String>,
+}
+
+impl DebPkgFileTrace {
+    pub fn new() -> Self {
+        let mut d = DebPkgFileTrace { file_to_pkg: HashMap::default() };
+        d.load();
+        d
+    }
+
+    /// Read dpkg cache. All of it.
+    fn load(&mut self) {
+        if let Ok(rd) = fs::read_dir("/var/lib/dpkg/info") {
+            for d in rd.filter_map(Result::ok).collect::<Vec<DirEntry>>() {
+                if d.path().to_str().unwrap().ends_with(".list") {
+                    self.load_pkg(d.path());
+                }
+            }
+        }
+    }
+
+    fn load_pkg(&mut self, pinfo: PathBuf) {
+        // Path to package name
+        let pkgname = &pinfo
+            .file_name()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap()
+            .strip_suffix(".list")
+            .unwrap()
+            .split(':')
+            .collect::<Vec<&str>>()[0];
+
+        if let Ok(pkg_data) = fs::read_to_string(&pinfo) {
+            for f_pth in pkg_data.split('\n').collect::<Vec<&str>>().iter().map(PathBuf::from) {
+                if f_pth.exists() && f_pth.is_file() {
+                    self.file_to_pkg.insert(f_pth, pkgname.to_string().to_owned());
+                }
+            }
+        }
+    }
+}
+
+impl PkgFileTrace for DebPkgFileTrace {
+    fn trace(&mut self, filename: PathBuf) -> Option<String> {
+        for p in RootFS::expand_target(filename, true) {
+            if let Some(pkg) = self.file_to_pkg.get(&p) {
+                return Some(pkg.to_owned());
+            }
+        }
+
+        None
+    }
+}

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,4 +1,5 @@
 pub mod binlib;
+pub mod debftrace;
 pub mod debpkg;
 pub(crate) mod dlst;
 pub mod general;

--- a/src/scanner/traceitf.rs
+++ b/src/scanner/traceitf.rs
@@ -1,5 +1,12 @@
+use std::path::PathBuf;
+
 /// Package dependency trace
 pub trait PkgDepTrace {
     fn trace(&mut self, pkgname: String) -> Vec<String>;
     fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self;
+}
+
+pub trait PkgFileTrace {
+    /// Return a package name, to which this file belongs to
+    fn trace(&mut self, filename: PathBuf) -> Option<String>;
 }


### PR DESCRIPTION
Output while converting `emacs-nox` into an app:

```
Kept 34 packages as follows:
  emacs-common, emacs-nox, libacl1, libasound2, libc6, libcap2,
  libdbus-1-3, libffi8, libgcc-s1, libgcrypt20, libgmp10, libgnutls30,
  libgpg-error0, libgpm2, libhogweed6, libicu70, libidn2-0, libjansson4,
  liblcms2-2, liblz4-1, liblzma5, libnettle8, libp11-kit0, libpcre2-8-0,
  libselinux1, libstdc++6, libsystemd0, libtasn1-6, libtinfo6, libunistring2,
  libxml2, libzstd1, ncurses-base, zlib1g
```

Emacs... `¯\_(ツ)_/¯`