### PR TITLE
Add software cloner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,7 +58,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -62,7 +68,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -70,6 +76,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -105,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,7 +133,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -174,7 +192,7 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -182,6 +200,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "deranged"
@@ -200,12 +227,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -221,6 +248,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -282,7 +331,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -308,15 +357,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -334,12 +383,36 @@ dependencies = [
  "colored",
  "exitcode",
  "filesize",
+ "flate2",
  "log",
+ "nix",
  "serde",
  "serde_yaml",
  "sys-info",
+ "tar",
  "time",
  "walkdir",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -382,16 +455,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.20"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -467,6 +549,17 @@ checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -627,7 +720,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -636,7 +729,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -645,13 +747,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -661,10 +779,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -673,10 +803,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -685,13 +833,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ dependencies = [
  "log",
  "serde",
  "serde_yaml",
+ "sys-info",
  "time",
  "walkdir",
 ]
@@ -456,6 +457,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ filesize = "0.2.0"
 log = "0.4.20"
 serde = { version = "1.0.188", features = ["derive", "alloc"] }
 serde_yaml = "0.9.25"
+sys-info = "0.9.1"
 time = "0.3.28"
 walkdir = "2.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,13 @@ clap = { version = "4.3.24", features = [
 colored = "2.0.4"
 exitcode = "1.1.2"
 filesize = "0.2.0"
+flate2 = "1.0.30"
 log = "0.4.20"
+nix = "0.29.0"
 serde = { version = "1.0.188", features = ["derive", "alloc"] }
 serde_yaml = "0.9.25"
 sys-info = "0.9.1"
+tar = "0.4.41"
 time = "0.3.28"
 walkdir = "2.4.0"
 

--- a/docs/cont-compose.rst
+++ b/docs/cont-compose.rst
@@ -1,0 +1,65 @@
+.. note::
+    This document describes another use case for migrating/moving
+    software from one container or system to another.
+
+.. _quickstart:
+
+Container Compositor
+====================
+
+It might look like this can be an unusual use case: **move installed software elsewhere**.
+
+What is this?
+-------------
+
+**Container Compositor** is a a use-case to compose a container from already provisioned root filesystem.
+Imagine, you have a fully provisioned root filesystem, which contains ``dnf`` or ``zypper`` or ``apt`` or whatever
+other Package Manager. In this case, one can just do this:
+
+.. code-block:: shell
+
+    zypper install ffmpeg <ENTER>
+
+This will result installing:
+
+- ``ffmpeg`` itself
+- additional required software dependencies and libraries *(around 180 Mb of stuff)*
+
+This is great, when you have RPM database and ``/usr/bin/zypper`` available. However, on your other minimal
+container, which has only Busybox available and glibc, no Zypper or any other package manager is available.
+In this case, you won't be able to install ``ffmpeg`` onto your container "just like that".
+
+What you would do is this:
+
+1. Provision a "regular" rootfs somewhere, such as using e.g. ``debootstrap`` or specifying the option ``--root`` for Zypper etc.
+2. Have a minimal rootfs for your future OCI container, e.g. using *dynamic* Busybox (with ``glibc`` around).
+3. Install whatever you want, using packages, into the "regular" rootfs.
+4. Move it in a stripped version to a minimal rootfs, which is your future OCI container.
+
+So in a nutshell:
+
+.. pull-quote::
+    .. rubric::
+        The "Container Compositor" feature allows to take ``ffmpeg`` and move it into a ``tar.gz`` archive with all required libraries and symlinks "as is", placed in those directories where they belong, including required artifacts from other packages.
+
+Think of "Mezzotint in reverse": instead of deleting everything else and leaving the container, it will
+take what is needed into an archive. Later on, you can unpack it at root point inside your container FS.
+
+.. warning::
+
+    This feature expects that you are moving yourt software around **only within the same distribution**!
+
+Usage
+-----
+
+The usage is identical to a typical Mezzotint use, except add ``--copy`` (or ``-c``) option as a filename
+for a future ``tar.gz`` archive. For example:
+
+.. code-block:: shell
+
+    mezzotint --exe /usr/bin/ffmpeg -r /path/to/my/rootfs --copy=ffmpeg
+
+This will grab everything that belongs to ``ffmpeg`` and place it into a ``ffmpeg.tar.gz`` archive, which
+will be located in ``/tmp`` directory of your *target rootfs**, in this case ``/path/to/my/rootfs/tmp/ffmpeg.tar.gz``.
+
+You can also use ``--dry-run`` (``-t``), profile and other features alltogether.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Welcome to Mezzotint documentation!
    installation
    quickstart
    usage
+   cont-compose
    manpage
    contributing
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -24,6 +24,9 @@ The following options are available:
 -t, --dry-run            Do not remove anything, only display what will be removed
 -a, --autodeps <mode>    Auto-add package dependencies. `NOTE: This can increase the size, but might not always be useful` Default value is set to `none`. Other possible values: `free`, `clean`, `tight` and default `none`.
 -r, --root <root>        Root filesystem, e.g. mountpoint of an image
+-c, --copy <copy>        Collect all library dependencies of a target executable,
+                         and copy everything to a specified directory.
+
 
 Filters
 -------

--- a/scripts/create-rootfs.sh
+++ b/scripts/create-rootfs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+#
+#
+
+# Enough args?
+if [ $# -lt 1 ]; then
+    echo 1>&2 "Usage: $(basename $0) DIR"
+    exit 3
+fi
+
+# Exists already?
+target=$1
+if [ -d "$target" ]; then
+    echo "Directory $target already exists"
+    exit 1
+fi
+
+sudo debootstrap --variant=minbase jammy $target http://ftp.halifax.rwth-aachen.de/ubuntu/

--- a/src/clidef.rs
+++ b/src/clidef.rs
@@ -60,6 +60,14 @@ pub fn cli(version: &'static str) -> Command {
                 .help(format!("Auto-add package dependencies.\n{}", " NOTE: This can increase the size, but might not always be useful\n".yellow()))
         )
         .arg(
+            Arg::new("delta-only")
+                .short('l')
+                .long("delta-only")
+                .action(clap::ArgAction::SetTrue)
+                .help(format!("Remove all identical files, those are found on the current host system.\n{}",
+                " NOTE: Installation of such app bundle container might be erroneous\n on other systems! Make sure this container is installed on \n the same distribution and its version!".yellow()))
+        )
+        .arg(
             Arg::new("root")
                 .short('r')
                 .long("root")

--- a/src/clidef.rs
+++ b/src/clidef.rs
@@ -59,6 +59,7 @@ pub fn cli(version: &'static str) -> Command {
                 .value_parser(["free", "clean", "tight", "none"])
                 .help(format!("Auto-add package dependencies.\n{}", " NOTE: This can increase the size, but might not always be useful\n".yellow()))
         )
+        /*
         .arg(
             Arg::new("delta-only")
                 .short('l')
@@ -67,6 +68,7 @@ pub fn cli(version: &'static str) -> Command {
                 .help(format!("Remove all identical files, those are found on the current host system.\n{}",
                 " NOTE: Installation of such app bundle container might be erroneous\n on other systems! Make sure this container is installed on \n the same distribution and its version!".yellow()))
         )
+        */
         .arg(
             Arg::new("root")
                 .short('r')

--- a/src/clidef.rs
+++ b/src/clidef.rs
@@ -74,6 +74,12 @@ pub fn cli(version: &'static str) -> Command {
                 .required_unless_present_any(["help", "version"])
                 .help("Root filesystem, e.g. mountpoint of an image")
         )
+        .arg(
+            Arg::new("copy")
+                .short('c')
+                .long("copy")
+                .help("Collect all library dependencies of a target executable,\nand copy everything to a specified directory.")
+        )
 
         // Filters
         .next_help_heading("Filters")

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn main() -> Result<(), std::io::Error> {
         .set_profile(get_profile(cli, &params))
         .set_dry_run(params.get_flag("dry-run"))
         .set_autodeps(params.get_one::<String>("autodeps").unwrap().to_string())
-        .copy_to(params.get_one::<String>("copy").unwrap_or_else(|| &default_empty))?
+        .copy_to(params.get_one::<String>("copy").unwrap_or(&default_empty))?
         .start()
     {
         log::error!("{}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod rootfs;
 mod scanner;
 mod shcall;
 use crate::profile::Profile;
-use clap::{error::ErrorKind, ArgMatches, Command};
+use clap::{ArgMatches, Command};
 use colored::Colorize;
 use std::{
     env,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod rootfs;
 mod scanner;
 mod shcall;
 use crate::profile::Profile;
-use clap::{ArgMatches, Command};
+use clap::{error::ErrorKind, ArgMatches, Command};
 use colored::Colorize;
 use std::{
     env,
@@ -115,6 +115,14 @@ fn main() -> Result<(), std::io::Error> {
     // Since --help is disabled on purpose in CLI definition, it is checked manually.
     if *params.get_one::<bool>("help").unwrap() {
         cli.print_help().unwrap();
+        return Ok(());
+    }
+
+    if *params.get_one::<bool>("delta-only").unwrap() {
+        if sys_info::os_type().unwrap_or_default().to_lowercase() != "linux" {
+            return Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "Unsupported OS. Only Linux for now..."));
+        }
+
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,7 @@ fn get_profile(mut cli: Command, params: &ArgMatches) -> Profile {
 
 /// Main
 fn main() -> Result<(), std::io::Error> {
+    let default_empty = String::from("");
     let args: Vec<String> = env::args().collect();
     let mut cli = clidef::cli(VERSION);
 
@@ -151,6 +152,7 @@ fn main() -> Result<(), std::io::Error> {
         .set_profile(get_profile(cli, &params))
         .set_dry_run(params.get_flag("dry-run"))
         .set_autodeps(params.get_one::<String>("autodeps").unwrap().to_string())
+        .copy_to(params.get_one::<String>("copy").unwrap_or_else(|| &default_empty))?
         .start()
     {
         log::error!("{}", err);

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use chrono::Local;
 use flate2::{write::GzEncoder, Compression};
-use log::info;
+use log::{info, warn};
 use std::{
     collections::HashSet,
     fs::{self, canonicalize, remove_file, DirEntry, File},

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -179,7 +179,7 @@ impl TintProcessor {
 
         // Cleanup
         fs::remove_dir_all(tmpdir)?;
-        info!("Package archive has been created at {:?}", self.root.join(archname.trim_start_matches("/")));
+        info!("Package archive has been created at {:?}", self.root.join(archname.trim_start_matches('/')));
 
         Ok(())
     }

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -158,7 +158,7 @@ impl TintProcessor {
         let tmpdir = PathBuf::from(format!(
             "/tmp/{}-{}",
             self.copy_to.as_ref().unwrap().file_name().unwrap().to_str().unwrap_or_default(),
-            Local::now().format("%Y%m%d%H%M%S").to_string()
+            Local::now().format("%Y%m%d%H%M%S")
         ));
 
         for src in paths {

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -167,7 +167,7 @@ impl TintProcessor {
                 fs::create_dir_all(dst.parent().unwrap())?;
             }
 
-            fs::copy(&src, &dst)?;
+            fs::copy(src, dst)?;
             info!("Archiving {:?}", src);
         }
 

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -183,11 +183,11 @@ impl TintProcessor {
 
         for target_path in self.profile.get_targets() {
             log::debug!("Find binary dependencies for {target_path}");
-            paths.extend(ElfScanner::new().scan(Path::new(target_path).to_owned()));
+            paths.extend(ElfScanner::new().scan(Path::new(target_path).to_owned()).get_paths().to_owned());
 
             log::debug!("Find package dependencies for {target_path}");
             // XXX: This will re-scan again and again, if target_path belongs to the same package
-            paths.extend(DebPackageScanner::new(self.autodeps).scan(Path::new(target_path).to_owned()));
+            paths.extend(DebPackageScanner::new(self.autodeps).scan(Path::new(target_path).to_owned()).get_paths().to_owned());
 
             // Add the target itself
             paths.insert(Path::new(target_path).to_owned());
@@ -253,7 +253,7 @@ impl TintProcessor {
             if self.profile.has_post_hook() {
                 log::debug!("Post-hook:\n{}", self.profile.get_post_hook());
             }
-            ContentFormatter::new(&paths).set_removed(&p).format();
+            ContentFormatter::new(&paths).set_removed(&p).set_bundled_packages(self.profile.get_bundled_packages()).format();
         } else {
             // Run post-hook (doesn't affect changes apply)
             if self.profile.has_post_hook() {

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -312,17 +312,15 @@ impl TintProcessor {
                 log::debug!("Post-hook:\n{}", self.profile.get_post_hook());
             }
             ContentFormatter::new(&paths).set_removed(&p).set_bundled_packages(self.profile.get_bundled_packages()).format();
+        } else if self.copy_to.is_some() {
+            self.into_archive(&paths)?;
         } else {
-            if self.copy_to.is_some() {
-                self.into_archive(&paths)?;
-            } else {
-                // Erase mode
-                if self.profile.has_post_hook() {
-                    // Run post-hook (doesn't affect changes apply)
-                    Self::call_script(self.profile.get_post_hook())?;
-                }
-                self.apply_changes(p)?;
+            // Erase mode
+            if self.profile.has_post_hook() {
+                // Run post-hook (doesn't affect changes apply)
+                Self::call_script(self.profile.get_post_hook())?;
             }
+            self.apply_changes(p)?;
         }
 
         Ok(())

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use chrono::Local;
 use flate2::{write::GzEncoder, Compression};
-use log::{info, warn};
+use log::info;
 use std::{
     collections::HashSet,
     fs::{self, canonicalize, remove_file, DirEntry, File},

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -227,7 +227,7 @@ impl TintProcessor {
             .filter(&mut paths);
 
         // Remove package content before dissection
-        // XXX: Exlude .so binaries also from the Elf reader?
+        // XXX: Exclude .so binaries also from the Elf reader?
         for p in self.profile.get_dropped_packages() {
             log::debug!("Removing dropped package contents from \"{}\"", p);
             for p in pscan.get_package_contents(p.to_string())? {

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -1,8 +1,3 @@
-use chrono::Local;
-use flate2::{write::GzEncoder, Compression};
-use log::{info, warn};
-use tar::Builder;
-
 use crate::{
     filters::{dirs::PathsDataFilter, intf::DataFilter, resources::ResourcesDataFilter, texts::TextDataFilter},
     profile::Profile,
@@ -10,14 +5,17 @@ use crate::{
     scanner::{binlib::ElfScanner, debpkg::DebPackageScanner, dlst::ContentFormatter, general::Scanner},
     shcall::ShellScript,
 };
-use core::arch;
+use chrono::Local;
+use flate2::{write::GzEncoder, Compression};
+use log::info;
 use std::{
     collections::HashSet,
     fs::{self, canonicalize, remove_file, DirEntry, File},
     io::{Error, ErrorKind},
-    os::{fd::AsRawFd, unix},
+    os::unix,
     path::{Path, PathBuf},
 };
+use tar::Builder;
 
 /// Autodependency mode
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -80,7 +80,7 @@ impl TintProcessor {
             return Ok(self);
         }
 
-        let mut p = PathBuf::from(dst);
+        let p = PathBuf::from(dst);
         if p.is_dir() {
             return Err(Error::new(ErrorKind::InvalidData, format!("{:?} is a directory", p)));
         } else if p.exists() {

--- a/src/procdata.rs
+++ b/src/procdata.rs
@@ -153,6 +153,7 @@ impl TintProcessor {
     }
 
     /// Archive paths that needs to be preserved
+    #[allow(clippy::wrong_self_convention)]
     fn into_archive(&self, paths: &Vec<PathBuf>) -> Result<(), Error> {
         let tmpdir = PathBuf::from(format!(
             "/tmp/{}-{}",

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -13,6 +13,7 @@ pub struct PConfig {
 pub struct PTargets {
     targets: Vec<String>,
     packages: Option<Vec<String>>,
+    bundled_packages: Option<Vec<String>>,
     config: Option<PConfig>,
     hooks: Option<PHooks>,
 }
@@ -38,6 +39,7 @@ pub struct Profile {
     f_expl_keep: Vec<PathBuf>,
 
     packages: Vec<String>,
+    bundled_packages: Vec<String>,
     dropped_packages: Vec<String>,
     targets: Vec<String>,
 
@@ -61,6 +63,7 @@ impl Profile {
             f_arc: true,
 
             packages: vec![],
+            bundled_packages: vec![],
             dropped_packages: vec![],
             targets: vec![],
             f_expl_prune: vec![],
@@ -141,6 +144,13 @@ impl Profile {
                 }
 
                 self.packages.push(p);
+            }
+        }
+
+        // Pass bundled packages
+        if let Some(pkgs) = p.bundled_packages {
+            for p in &pkgs {
+                self.bundled_packages.push(p.to_string());
             }
         }
 
@@ -289,6 +299,11 @@ impl Profile {
     /// Get packages
     pub fn get_packages(&self) -> &Vec<String> {
         &self.packages
+    }
+
+    /// Get bundled packages configuration
+    pub fn get_bundled_packages(&self) -> &Vec<String> {
+        &self.bundled_packages
     }
 
     /// Get dropped packages

--- a/src/scanner/binlib.rs
+++ b/src/scanner/binlib.rs
@@ -1,5 +1,7 @@
 use crate::scanner::general::{Scanner, ScannerCommons};
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, error::Error, path::PathBuf};
+
+use super::general::ScannerResult;
 
 pub struct ElfScanner {
     commons: ScannerCommons,
@@ -37,13 +39,20 @@ impl ElfScanner {
 
 impl Scanner for ElfScanner {
     /// Scan for the required dynamic libraries in an executable
-    fn scan(&mut self, pth: PathBuf) -> Vec<PathBuf> {
+    fn scan(&mut self, pth: PathBuf) -> ScannerResult {
         log::debug!("Scanning for dependencies in {}", pth.to_str().unwrap());
-        self.get_dynlibs(pth.to_str().unwrap().to_string()).iter().map(PathBuf::from).collect::<Vec<PathBuf>>()
+        ScannerResult::new(
+            self.get_dynlibs(pth.to_str().unwrap().to_string()).iter().map(PathBuf::from).collect::<Vec<PathBuf>>(),
+        )
     }
 
     /// Bogus trait implementation, does nothing in this case
     fn exclude(&mut self, _: Vec<String>) -> &mut Self {
         self
+    }
+
+    /// Dummy
+    fn contents(&mut self, pkgname: String) -> Result<ScannerResult, std::io::Error> {
+        Err(std::io::Error::new(std::io::ErrorKind::Unsupported, ""))
     }
 }

--- a/src/scanner/binlib.rs
+++ b/src/scanner/binlib.rs
@@ -51,7 +51,7 @@ impl Scanner for ElfScanner {
     }
 
     /// Dummy
-    fn contents(&mut self, pkgname: String) -> Result<ScannerResult, std::io::Error> {
+    fn contents(&mut self, _pkgname: String) -> Result<ScannerResult, std::io::Error> {
         Err(std::io::Error::new(std::io::ErrorKind::Unsupported, ""))
     }
 }

--- a/src/scanner/binlib.rs
+++ b/src/scanner/binlib.rs
@@ -1,7 +1,6 @@
-use crate::scanner::general::{Scanner, ScannerCommons};
-use std::{collections::HashSet, error::Error, path::PathBuf};
-
 use super::general::ScannerResult;
+use crate::scanner::general::{Scanner, ScannerCommons};
+use std::{collections::HashSet, path::PathBuf};
 
 pub struct ElfScanner {
     commons: ScannerCommons,

--- a/src/scanner/debftrace.rs
+++ b/src/scanner/debftrace.rs
@@ -1,6 +1,5 @@
-use crate::rootfs::RootFS;
-
 use super::traceitf::PkgFileTrace;
+use crate::rootfs::RootFS;
 use std::{
     collections::HashMap,
     fs::{self, DirEntry},

--- a/src/scanner/debpkg.rs
+++ b/src/scanner/debpkg.rs
@@ -1,12 +1,13 @@
 use crate::{
     procdata::Autodeps,
     scanner::{
-        general::{Scanner, ScannerCommons},
+        general::{Scanner, ScannerCommons, ScannerResult},
         tracedeb,
         traceitf::PkgDepTrace,
     },
 };
 use colored::Colorize;
+use filesize::PathExt;
 use std::{
     collections::HashSet,
     io::{Error, ErrorKind},
@@ -93,7 +94,12 @@ impl DebPackageScanner {
 }
 
 impl Scanner for DebPackageScanner {
-    fn scan(&mut self, pth: PathBuf) -> Vec<PathBuf> {
+    fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self {
+        self.excluded_packages.extend(pkgs);
+        self
+    }
+
+    fn scan(&mut self, pth: PathBuf) -> ScannerResult {
         log::debug!("Scanning package contents for {:?}", pth.to_str());
 
         let mut out: Vec<PathBuf> = vec![];
@@ -130,11 +136,14 @@ impl Scanner for DebPackageScanner {
             }
         }
 
-        out
+        // Return as an encapsulated object for future reuses
+        ScannerResult::new(out)
     }
 
-    fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self {
-        self.excluded_packages.extend(pkgs);
-        self
+    fn contents(&mut self, pkgname: String) -> Result<ScannerResult, Error> {
+        match self.get_package_contents(pkgname) {
+            Ok(fp) => Ok(ScannerResult::new(fp)),
+            Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        }
     }
 }

--- a/src/scanner/debpkg.rs
+++ b/src/scanner/debpkg.rs
@@ -7,7 +7,6 @@ use crate::{
     },
 };
 use colored::Colorize;
-use filesize::PathExt;
 use std::{
     collections::HashSet,
     io::{Error, ErrorKind},

--- a/src/scanner/deltafinder.rs
+++ b/src/scanner/deltafinder.rs
@@ -7,9 +7,8 @@
     symlinks in place.
 */
 
-use std::path::PathBuf;
-
 use super::{debftrace::DebPkgFileTrace, rpmftrace::RpmPkgFileTrace, traceitf::PkgFileTrace};
+use std::path::PathBuf;
 
 pub struct DeltaFinder {
     dupes: Vec<PathBuf>,

--- a/src/scanner/deltafinder.rs
+++ b/src/scanner/deltafinder.rs
@@ -36,19 +36,19 @@ impl DeltaFinder {
 
     /// Test if a given path has a carbon copy on the current system
     /// NOTE: DeltaFinder is looking for either a current system or a mounted fs!
-    pub fn maybe_dupe(self, f: PathBuf) -> bool {
+    pub fn maybe_dupe(&self, f: PathBuf) -> bool {
         let mut is_dupe = false;
         is_dupe
     }
 
-    fn is_same(self) -> bool {
+    fn is_same(&self) -> bool {
         false
     }
 
-    fn belongs_to(self) {}
+    fn belongs_to(&self) {}
 
     /// Get collected duplicates
-    pub fn get_dupes(self) -> Vec<PathBuf> {
+    pub fn get_dupes(&self) -> Vec<PathBuf> {
         self.dupes.to_owned()
     }
 }

--- a/src/scanner/deltafinder.rs
+++ b/src/scanner/deltafinder.rs
@@ -1,5 +1,6 @@
 /*
     This is only useful if a container is a flake (https://github.com/Elektrobit/flake-pilot),
+    or a software needs to be cut out to the exactly same repository but a smaller size,
     i.e. is packaged for the very system and is guaranteed to be running on it.
 
     Delta finder will post-remove every file, which is *exactly* the same on the host machine,

--- a/src/scanner/deltafinder.rs
+++ b/src/scanner/deltafinder.rs
@@ -19,7 +19,7 @@ pub struct DeltaFinder {
 
 impl DeltaFinder {
     pub fn new(rootfs: Option<PathBuf>) -> Self {
-        let debian_family = vec!["ubuntu", "debian", "mint"];
+        let debian_family = ["ubuntu", "debian", "mint"];
         //let redhat_family = vec!["redhat", "fedora", "suse", "sles", "opensuse-leap", "opensuse"];
 
         let os_id = sys_info::linux_os_release().unwrap().id().to_lowercase();

--- a/src/scanner/deltafinder.rs
+++ b/src/scanner/deltafinder.rs
@@ -11,44 +11,43 @@
 use super::{debftrace::DebPkgFileTrace, rpmftrace::RpmPkgFileTrace, traceitf::PkgFileTrace};
 use std::path::PathBuf;
 
-pub struct DeltaFinder {
+pub struct _DeltaFinder {
     dupes: Vec<PathBuf>,
     rootfs: PathBuf,
     pkgtrace: Box<dyn PkgFileTrace>,
 }
 
-impl DeltaFinder {
-    pub fn new(rootfs: Option<PathBuf>) -> Self {
+impl _DeltaFinder {
+    pub fn _new(rootfs: Option<PathBuf>) -> Self {
         let debian_family = ["ubuntu", "debian", "mint"];
         //let redhat_family = vec!["redhat", "fedora", "suse", "sles", "opensuse-leap", "opensuse"];
 
         let os_id = sys_info::linux_os_release().unwrap().id().to_lowercase();
-        DeltaFinder {
+        _DeltaFinder {
             dupes: Vec::new(),
             rootfs: rootfs.unwrap_or(PathBuf::from("/")),
             pkgtrace: if debian_family.contains(&os_id.as_str()) {
                 Box::new(DebPkgFileTrace::new())
             } else {
-                Box::new(RpmPkgFileTrace::new())
+                Box::new(RpmPkgFileTrace::_new())
             },
         }
     }
 
     /// Test if a given path has a carbon copy on the current system
     /// NOTE: DeltaFinder is looking for either a current system or a mounted fs!
-    pub fn maybe_dupe(&self, f: PathBuf) -> bool {
-        let mut is_dupe = false;
-        is_dupe
-    }
-
-    fn is_same(&self) -> bool {
+    pub fn _maybe_dupe(&self, _f: PathBuf) -> bool {
         false
     }
 
-    fn belongs_to(&self) {}
+    fn _is_same(&self) -> bool {
+        false
+    }
+
+    fn _belongs_to(&self) {}
 
     /// Get collected duplicates
-    pub fn get_dupes(&self) -> Vec<PathBuf> {
+    pub fn _get_dupes(&self) -> Vec<PathBuf> {
         self.dupes.to_owned()
     }
 }

--- a/src/scanner/deltafinder.rs
+++ b/src/scanner/deltafinder.rs
@@ -1,0 +1,54 @@
+/*
+    This is only useful if a container is a flake (https://github.com/Elektrobit/flake-pilot),
+    i.e. is packaged for the very system and is guaranteed to be running on it.
+
+    Delta finder will post-remove every file, which is *exactly* the same on the host machine,
+    and then symlink them so when that container will be properly mounted, it will have all
+    symlinks in place.
+*/
+
+use std::path::PathBuf;
+
+use super::{debftrace::DebPkgFileTrace, rpmftrace::RpmPkgFileTrace, traceitf::PkgFileTrace};
+
+pub struct DeltaFinder {
+    dupes: Vec<PathBuf>,
+    rootfs: PathBuf,
+    pkgtrace: Box<dyn PkgFileTrace>,
+}
+
+impl DeltaFinder {
+    pub fn new(rootfs: Option<PathBuf>) -> Self {
+        let debian_family = vec!["ubuntu", "debian", "mint"];
+        //let redhat_family = vec!["redhat", "fedora", "suse", "sles", "opensuse-leap", "opensuse"];
+
+        let os_id = sys_info::linux_os_release().unwrap().id().to_lowercase();
+        DeltaFinder {
+            dupes: Vec::new(),
+            rootfs: rootfs.unwrap_or(PathBuf::from("/")),
+            pkgtrace: if debian_family.contains(&os_id.as_str()) {
+                Box::new(DebPkgFileTrace::new())
+            } else {
+                Box::new(RpmPkgFileTrace::new())
+            },
+        }
+    }
+
+    /// Test if a given path has a carbon copy on the current system
+    /// NOTE: DeltaFinder is looking for either a current system or a mounted fs!
+    pub fn maybe_dupe(self, f: PathBuf) -> bool {
+        let mut is_dupe = false;
+        is_dupe
+    }
+
+    fn is_same(self) -> bool {
+        false
+    }
+
+    fn belongs_to(self) {}
+
+    /// Get collected duplicates
+    pub fn get_dupes(self) -> Vec<PathBuf> {
+        self.dupes.to_owned()
+    }
+}

--- a/src/scanner/dlst.rs
+++ b/src/scanner/dlst.rs
@@ -41,7 +41,7 @@ impl<'a> ContentFormatter<'a> {
 
     /// Set known bundled packages from the profile, when creating system-bound AppBundle
     pub(crate) fn set_bundled_packages(&mut self, bp: &'a Vec<String>) -> &mut Self {
-        if bp.len() == 0 {
+        if !bp.is_empty() {
             return self;
         }
         self.bundled_packages = Some(bp);
@@ -73,7 +73,7 @@ impl<'a> ContentFormatter<'a> {
         // XXX: Depends on the system
         let mut pt: Box<dyn PkgFileTrace> = Box::new(DebPkgFileTrace::new());
 
-        self.fs_data.into_iter().for_each(|p: &PathBuf| {
+        self.fs_data.iter().for_each(|p: &PathBuf| {
             if let Some(pkg) = pt.trace(p.clone()) {
                 pkgs.insert(pkg);
             }
@@ -192,7 +192,7 @@ impl<'a> ContentFormatter<'a> {
             pkgs.join(", ")
         );
 
-        if s_pkgs.len() > 0 {
+        if !s_pkgs.is_empty() {
             println!(
                 "{} {} {} {}\n  {}\n",
                 s_pkgs.len().to_string().bright_yellow(),

--- a/src/scanner/dlst.rs
+++ b/src/scanner/dlst.rs
@@ -2,6 +2,7 @@
 Data lister (fancy STDOUT printer)
 */
 
+use super::{debpkg::DebPackageScanner, general::Scanner};
 use crate::{
     filters::resources,
     procdata,
@@ -15,9 +16,6 @@ use std::{
     os::unix::prelude::PermissionsExt,
     path::{Path, PathBuf},
 };
-use sys_info::proc_total;
-
-use super::{debpkg::DebPackageScanner, general::Scanner};
 
 /// ContentFormatter is a lister for finally gathered information,
 /// that needs to be displayed on the screen for the user for review

--- a/src/scanner/dlst.rs
+++ b/src/scanner/dlst.rs
@@ -118,7 +118,7 @@ impl<'a> ContentFormatter<'a> {
             let (dname, mut fname) = self.dn(p);
 
             if self.last_dir != dname {
-                self.last_dir = dname.to_owned();
+                dname.clone_into(&mut self.last_dir);
                 t_leaf = "".to_string();
                 println!("\n{}", self.last_dir.bright_blue().bold());
                 println!("{}", "──┬──┄┄╌╌ ╌  ╌".blue());

--- a/src/scanner/general.rs
+++ b/src/scanner/general.rs
@@ -7,6 +7,7 @@ pub(crate) trait Scanner {
     fn scan(&mut self, pth: PathBuf) -> ScannerResult;
 
     /// Add packages to be excluded from the scan
+    #[allow(dead_code)]
     fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self;
 
     fn contents(&mut self, pkgname: String) -> Result<ScannerResult, std::io::Error>;
@@ -76,7 +77,7 @@ impl ScannerCommons {
         if self.elfrd_p.is_empty() {
             for p in &self.elfrd_paths {
                 if fs::metadata(p).is_ok() {
-                    self.elfrd_p = p.to_owned();
+                    p.clone_into(&mut self.elfrd_p);
                     break;
                 }
             }

--- a/src/scanner/general.rs
+++ b/src/scanner/general.rs
@@ -1,4 +1,4 @@
-use std::{default, fs, io::Error, path::PathBuf, process::Command};
+use std::{fs, io::Error, path::PathBuf, process::Command};
 
 use filesize::PathExt;
 

--- a/src/scanner/general.rs
+++ b/src/scanner/general.rs
@@ -1,13 +1,48 @@
-use std::{fs, io::Error, path::PathBuf, process::Command};
+use std::{default, fs, io::Error, path::PathBuf, process::Command};
+
+use filesize::PathExt;
 
 pub(crate) trait Scanner {
     /// Scan path
-    fn scan(&mut self, pth: PathBuf) -> Vec<PathBuf>;
+    fn scan(&mut self, pth: PathBuf) -> ScannerResult;
 
     /// Add packages to be excluded from the scan
     fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self;
+
+    fn contents(&mut self, pkgname: String) -> Result<ScannerResult, std::io::Error>;
 }
 
+/// Results of the scanner
+#[derive(Default)]
+pub struct ScannerResult {
+    paths: Vec<PathBuf>,
+    size: i128,
+}
+
+impl ScannerResult {
+    /// Constructor
+    pub fn new(paths: Vec<PathBuf>) -> Self {
+        ScannerResult { paths, size: 0 }
+    }
+
+    /// Returns package total size on the disk
+    pub fn get_size(&mut self) -> i128 {
+        // Lazy size scanner, in some cases this is not needed.
+        if self.paths.len() > 0 && self.size == 0 {
+            for p in &self.paths {
+                if let Ok(s) = p.as_path().size_on_disk() {
+                    self.size += s as i128;
+                }
+            }
+        }
+        self.size
+    }
+
+    /// Returns package paths
+    pub fn get_paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+}
 pub struct ScannerCommons {
     elfrd_paths: Vec<String>,
     elfrd_p: String,

--- a/src/scanner/general.rs
+++ b/src/scanner/general.rs
@@ -28,7 +28,7 @@ impl ScannerResult {
     /// Returns package total size on the disk
     pub fn get_size(&mut self) -> i128 {
         // Lazy size scanner, in some cases this is not needed.
-        if self.paths.len() > 0 && self.size == 0 {
+        if !self.paths.is_empty() && self.size == 0 {
             for p in &self.paths {
                 if let Ok(s) = p.as_path().size_on_disk() {
                     self.size += s as i128;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,7 +1,9 @@
 pub mod binlib;
 pub mod debftrace;
 pub mod debpkg;
+mod deltafinder;
 pub(crate) mod dlst;
 pub mod general;
+pub mod rpmftrace;
 pub mod tracedeb;
 pub mod traceitf;

--- a/src/scanner/rpmftrace.rs
+++ b/src/scanner/rpmftrace.rs
@@ -4,17 +4,17 @@ use super::traceitf::PkgFileTrace;
 
 /// Trace what package a give file belongs to, using RPM package manager.
 pub struct RpmPkgFileTrace {
-    file_to_pkg: HashMap<PathBuf, String>,
+    _file_to_pkg: HashMap<PathBuf, String>,
 }
 
 impl RpmPkgFileTrace {
-    pub fn new() -> Self {
-        RpmPkgFileTrace { file_to_pkg: HashMap::default() }
+    pub fn _new() -> Self {
+        RpmPkgFileTrace { _file_to_pkg: HashMap::default() }
     }
 }
 
 impl PkgFileTrace for RpmPkgFileTrace {
-    fn trace(&mut self, filename: PathBuf) -> Option<String> {
+    fn trace(&mut self, _filename: PathBuf) -> Option<String> {
         None
     }
 }

--- a/src/scanner/rpmftrace.rs
+++ b/src/scanner/rpmftrace.rs
@@ -1,0 +1,20 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use super::traceitf::PkgFileTrace;
+
+/// Trace what package a give file belongs to, using RPM package manager.
+pub struct RpmPkgFileTrace {
+    file_to_pkg: HashMap<PathBuf, String>,
+}
+
+impl RpmPkgFileTrace {
+    pub fn new() -> Self {
+        RpmPkgFileTrace { file_to_pkg: HashMap::default() }
+    }
+}
+
+impl PkgFileTrace for RpmPkgFileTrace {
+    fn trace(&mut self, filename: PathBuf) -> Option<String> {
+        None
+    }
+}

--- a/src/scanner/tracedeb.rs
+++ b/src/scanner/tracedeb.rs
@@ -64,7 +64,7 @@ impl PkgDepTrace for DebPackageTrace {
         d
     }
 
-    fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self {
+    fn exclude(&mut self, pkgs: Vec<String>) -> &mut dyn PkgDepTrace {
         self.exclude.extend(pkgs);
         self
     }

--- a/src/scanner/traceitf.rs
+++ b/src/scanner/traceitf.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 /// Package dependency trace
 pub trait PkgDepTrace {
     fn trace(&mut self, pkgname: String) -> Vec<String>;
-    fn exclude(&mut self, pkgs: Vec<String>) -> &mut Self;
+    fn exclude(&mut self, pkgs: Vec<String>) -> &mut dyn PkgDepTrace;
 }
 
 pub trait PkgFileTrace {


### PR DESCRIPTION
This PR adds a possibility to find only a true delta difference between the container and the target system.

This is only useful if the container is meant for the current OS with the current version for installation segregation. Running this functionality on a different host system is also useful to find same files that always comes identical (e.g. standard Python libraries etc). However, in this case the amount of different files might be very minimal, if at all.